### PR TITLE
Fix double 'in' for .next command

### DIFF
--- a/src/commands/showtimes_next.js
+++ b/src/commands/showtimes_next.js
@@ -49,7 +49,7 @@ export class ShowtimesNext extends Command {
     }
 
     const date = moment(new Date(json.air_date)).fromNow();
-    return `Air date: ${json.alias} #${json.episode_number} airs in ${date}`;
+    return `Air date: ${json.alias} #${json.episode_number} airs ${date}`;
   }
 
   help(from) {


### PR DESCRIPTION
My OCD couldn't handle this.